### PR TITLE
Bug fix to prevent symmetry protocol output in project root

### DIFF
--- a/dials/protocols/protocol_dials_base.py
+++ b/dials/protocols/protocol_dials_base.py
@@ -43,6 +43,7 @@ class DialsProtBase(EdBaseProtocol):
     INPUT_REFL_FILENAME = 'input.refl'
     OUTPUT_REFL_FILENAME = 'output.refl'
     OUTPUT_HTML_FILENAME = 'dials.report.html'
+    OUTPUT_JSON_FILENAME = "dials.program.json"
 
     # -------------------------- STEPS functions -----------------------------
 
@@ -71,6 +72,9 @@ class DialsProtBase(EdBaseProtocol):
 
     def getOutputReflFile(self):
         return self._getExtraPath(self.OUTPUT_REFL_FILENAME)
+
+    def getOutputJsonFile(self):
+        return self._getExtraPath(self.OUTPUT_JSON_FILENAME)
 
     def getProjectName(self, newProjectName=None):
         # Function to get the name of the overall project.

--- a/dials/protocols/protocol_symmetry.py
+++ b/dials/protocols/protocol_symmetry.py
@@ -27,7 +27,6 @@
 # **************************************************************************
 
 import pyworkflow.protocol as pwprot
-import pyworkflow.utils as pwutils
 import dials.utils as dutils
 
 from dials.protocols import DialsProtBase, PhilBase, CliBase, HtmlBase
@@ -35,7 +34,7 @@ from dials.constants import *
 import dials.convert as dconv
 
 
-class DialsProtSymmetry(DialsProtBase):
+class DialsProtSymmetry(DialsProtBase, HtmlBase):
     """ Protocol for checking symmetry of integrated spots using the
     POINTLESS algorithm as implemented in DIALS
     """
@@ -61,7 +60,7 @@ class DialsProtSymmetry(DialsProtBase):
         CliBase._defineCliParams(self, form)
 
         # Add a section for creating an html report
-        HtmlBase._defineHtmlParams(self, form)
+        self._defineHtmlParams(form)
 
    # -------------------------- INSERT functions ------------------------------
 
@@ -127,6 +126,8 @@ class DialsProtSymmetry(DialsProtBase):
     OUTPUT_EXPT_FILENAME = 'symmetrized.expt'
     INPUT_REFL_FILENAME = 'integrated.refl'
     OUTPUT_REFL_FILENAME = 'symmetrized.refl'
+    OUTPUT_HTML_FILENAME = "dials.symmetry.html"
+    OUTPUT_JSON_FILENAME = "dials.symmetry.json"
 
     def getLogOutput(self):
         logOutput = dutils.readLog(
@@ -134,6 +135,12 @@ class DialsProtSymmetry(DialsProtBase):
             'Recommended',
             'Saving')
         return logOutput.strip()
+
+    def _extraParams(self):
+        params = ""
+        params += f" output.html={self.getOutputHtmlFile()}"
+        params += f" output.json={self.getOutputJsonFile()}"
+        return params
 
     # -------------------------- UTILS functions ------------------------------
 

--- a/dials/tests/test_ed_dials.py
+++ b/dials/tests/test_ed_dials.py
@@ -616,7 +616,10 @@ class TestEdDialsProtocols(pwtests.BaseTest):
                 f"{protIntegrate._getExtraPath()}/integrated_reflections.refl "
                 f"output.log={protSymmetry._getLogsPath()}/dials.symmetry.log "
                 f"output.experiments={protSymmetry._getExtraPath()}/symmetrized.expt "
-                f"output.reflections={protSymmetry._getExtraPath()}/symmetrized.refl")
+                f"output.reflections={protSymmetry._getExtraPath()}/symmetrized.refl "
+                f"output.html={protSymmetry._getExtraPath()}/dials.symmetry.html "
+                f"output.json={protSymmetry._getExtraPath()}/dials.symmetry.json"
+            )
 
             self.assertCommand(protSymmetry, symmCL, 'dials.symmetry')
             symmetrizedset = getattr(
@@ -1007,7 +1010,10 @@ class TestEdDialsProtocols(pwtests.BaseTest):
             f"{protIntegrate._getExtraPath()}/integrated_reflections.refl "
             f"output.log={protSymmetry._getLogsPath()}/dials.symmetry.log "
             f"output.experiments={protSymmetry._getExtraPath()}/symmetrized.expt "
-            f"output.reflections={protSymmetry._getExtraPath()}/symmetrized.refl")
+            f"output.reflections={protSymmetry._getExtraPath()}/symmetrized.refl "
+            f"output.html={protSymmetry._getExtraPath()}/dials.symmetry.html "
+            f"output.json={protSymmetry._getExtraPath()}/dials.symmetry.json"
+        )
         self.assertCommand(protSymmetry, symmCL, 'dials.symmetry')
         symmetrizedset = getattr(
             protSymmetry, 'outputSymmetrizedSpots', None)


### PR DESCRIPTION
Adds extra output to ensure that html and json files from the symmetry protocol ends up in the protocol extras folder, not the project root
Fixes #29